### PR TITLE
Improving tokenizer performance by initialising input array beforehand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+compiler.exe

--- a/compiler.go
+++ b/compiler.go
@@ -361,16 +361,16 @@ func tokenizer(input string) []token {
 
 	// And a slice of our `token` type for appending tokens to.
 	tokens := []token{}
-
+	inputArr := []rune(input)
 	// We start by creating a `for` loop where we are setting up our `current`
 	// variable to be incremented as much as we want `inside` the loop.
 	//
 	// We do this because we may want to increment `current` many times within a
 	// single loop because our tokens can be any length.
-	for current < len([]rune(input)) {
+	for current < len(inputArr) {
 
 		// We're also going to store the `current` character in the `input`.
-		char := string([]rune(input)[current])
+		char := string(inputArr[current])
 
 		// The first thing we want to check for is an open parenthesis. This will
 		// later be used for `CallExpressions` but for now we only care about the

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module compiler
+
+go 1.22.5


### PR DESCRIPTION
The `tokenizer` function was computing the length of the input on the fly i.e. `for current < len([]rune(input))`. While it's not that big of a deal, it forces the compiler to re-compute the array for each iteration of the loop. Instead, what I did was that I calculated the array beforehand and then passed it to the loop as well as the line that required the `current` character in the `input`.